### PR TITLE
Stringify keys and remove zero balances for Node RPC call responses

### DIFF
--- a/lib/banano/node.rb
+++ b/lib/banano/node.rb
@@ -45,7 +45,8 @@ module Banano
 
     # @return [Hash{Symbol=>String}] information about the node peers
     def peers
-      rpc(action: :peers)[:peers]
+      h = -> (h) { Hash[h.map{ |k,v| [k.to_s, v] }] }
+      h.call(rpc(action: :peers)[:peers])
     end
 
     # All representatives and their voting weight.
@@ -54,6 +55,7 @@ module Banano
     # @return [Hash{Symbol=>Integer}] known representatives and their voting weight
     def representatives(raw = true)
       response = rpc(action: :representatives)[:representatives]
+      response = response.delete_if {|_, balance| balance.to_s == '0' } # remove 0 balance reps
       return response if raw == true
 
       r = response.map do |address, balance|


### PR DESCRIPTION
Some of the responses from the Node RPC were with not very convenient format
- peer addresses were symbol of string `:'::fff:....'`, converted to regular address strings
- representative response contained a lot of items with zero balance. not good to choice them to represent the node. removed from the response